### PR TITLE
Add run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,29 @@ https://nodejs-rest-api.innokentii-kozlov.com/api - API Swagger Documentation.
  - [x] GitHub Actions
  - [x] Postgres & TypeOrm
  - [x] Jest
+
+## Getting Started
+
+These instructions show how to run the database and API locally using Docker. Make sure you have [Docker](https://www.docker.com/) and [Make](https://www.gnu.org/software/make/) installed.
+
+### 1. Generate TLS certificates
+
+```bash
+make generate-tls-certificates
+```
+
+### 2. Start the database
+
+This command starts a PostgreSQL container and runs the initial migrations.
+
+```bash
+make database-start-local
+```
+
+### 3. Start the API
+
+```bash
+make api-start-local
+```
+
+The API will be available at `https://localhost:4430` by default.

--- a/api/README.md
+++ b/api/README.md
@@ -1,1 +1,22 @@
 # Api Service
+
+This service exposes the REST API built with [NestJS](https://nestjs.com/).
+
+## Running locally
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run start:dev
+```
+
+The API listens on the port defined in `infrastructure/docker/.env` (default `3000`).
+
+You can also run the API using Docker:
+
+```bash
+make api-start-local
+```
+
+This will start the prebuilt container defined in `infrastructure/docker/docker-compose.yaml`.

--- a/data/README.md
+++ b/data/README.md
@@ -1,1 +1,14 @@
-# Datasource and migrations service
+# Datasource and Migrations Service
+
+This package contains the TypeORM datasource and database migrations used by the API.
+
+## Running migrations locally
+
+Install dependencies and run the migrations:
+
+```bash
+npm install
+npm run migrations:run
+```
+
+When using Docker the migrations are executed automatically by `make database-start-local`.


### PR DESCRIPTION
## Summary
- document how to start services in the main README
- expand API README with local run steps
- expand Data README with instructions for migrations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853c19cb45083218dc4ee7ee169241a